### PR TITLE
Fix tags setting.

### DIFF
--- a/tfjs_graph_converter/converter.py
+++ b/tfjs_graph_converter/converter.py
@@ -109,7 +109,7 @@ def convert(arguments):
         api.graph_model_to_frozen_graph(args.input_path, args.output_path)
     elif args.output_format == common.CLI_SAVED_MODEL:
         api.graph_model_to_saved_model(
-            args.input_path, args.output_path, args.saved_model_tags)
+            args.input_path, args.output_path, [x for x in args.saved_model_tags.split(',')])
     else:
         raise ValueError(f"Unsupported output format: {args.output_format}")
 


### PR DESCRIPTION
Current implementation was setting 5 for instance different tags 's', 'e', 'r', 'v', 'e' in default mode by listing the string instead of taking it as a whole.

Now it's ok, it handles the multi tagging by comma separator